### PR TITLE
allow non-GET requests in CORS

### DIFF
--- a/src/main/java/com/nighthawk/spring_portfolio/system/MvcConfig.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/system/MvcConfig.java
@@ -31,7 +31,8 @@ public class MvcConfig implements WebMvcConfigurer {
     
     @Override
     public void addCorsMappings(@NonNull CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins("https://spring2025.nighthawkcodingsociety.com", "https://nighthawkcoders.github.io", "http://127.0.0.1:4100", "http://localhost:4100");
+        registry.addMapping("/**").allowedOrigins("https://spring2025.nighthawkcodingsociety.com", "https://nighthawkcoders.github.io", "http://127.0.0.1:4100", "http://localhost:4100")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
     }
     
 }


### PR DESCRIPTION
Current setup allows requests from correct origins but does not specific what type of requests and only allows get requests. Change allows GET, POST, PUT, DELETE, and OPTIONS requests to the backend.