### PR TITLE
Fixing DB Persistence (IMPORTANT)

### DIFF
--- a/src/main/java/com/nighthawk/spring_portfolio/mvc/backups/BackupsController.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/mvc/backups/BackupsController.java
@@ -1,9 +1,7 @@
 package com.nighthawk.spring_portfolio.mvc.backups;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,9 +10,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.*;
+import java.util.Date;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.Date;
 
 @RestController
 @RequestMapping("/api/exports/")
@@ -99,10 +97,23 @@ public class BackupsController {
                 for (int i = 1; i <= columnCount; i++) {
                     String columnName = metaData.getColumnName(i);
                     Object columnValue = resultSet.getObject(i);
+
+                    // Handle special fields (e.g., stats, kasm_server_needed)
+                    if (columnName.equals("stats") && columnValue instanceof String) {
+                        // If stats is stored as a string, parse it as JSON
+                        columnValue = objectMapper.readValue((String) columnValue, Map.class);
+                    } else if (columnName.equals("kasm_server_needed") && columnValue instanceof Integer) {
+                        // If kasm_server_needed is stored as an integer, convert it to boolean
+                        columnValue = ((Integer) columnValue) == 1;
+                    }
+
                     row.put(columnName, columnValue);
                 }
                 tableData.add(row);
             }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new SQLException("Failed to retrieve data from table: " + tableName, e);
         }
 
         return tableData;


### PR DESCRIPTION
- Added special handling for the Stats and Kasm column of the Person DB (they were breaking functionality)
- Added SQLITE DB integrity checks at startup to ensure the sqlite.db isn't corrupted
- Added Special handling for sequence databases to get rid of duplicate entries
- Added Special handling for new sequence databases 
- I guess this also stops the server from automatically crashing on startup